### PR TITLE
fix: default to hiding unavailable actions

### DIFF
--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -75,7 +75,7 @@ export function register (updateFunc) {
         scope: 'client',
         config: true,
         type: Boolean,
-        default: true,
+        default: false,
         onChange: (value) => {
             updateFunc(value)
         }
@@ -91,7 +91,7 @@ export function register (updateFunc) {
         scope: 'client',
         config: true,
         type: Boolean,
-        default: true,
+        default: false,
         onChange: (value) => {
             updateFunc(value)
         }


### PR DESCRIPTION
Default to hiding unprepared spells and unequipped items.

This makes more sense to hide actions not currently available to the player by default. Also matches the behavior presented to hide uncharged items.