### PR TITLE
Ensure `await` is used on async builders

### DIFF
--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -154,13 +154,13 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
                 this.#buildConditions(),
                 this.#buildFeatures(),
                 this.#buildInventory(),
-                this.#buildSpells()
+                this.#buildSpells(),
+                this.#buildEffects()
             ])
             this.#buildAbilities('ability', 'abilities')
             this.#buildAbilities('check', 'checks')
             this.#buildAbilities('save', 'saves')
             this.#buildCombat()
-            this.#buildEffects()
             this.#buildRests()
             this.#buildSkills()
             this.#buildUtility()
@@ -175,13 +175,13 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
             await Promise.all([
                 this.#buildConditions(),
                 this.#buildFeatures(),
-                this.#buildInventory()
+                this.#buildInventory(),
+                this.#buildEffects()
             ])
             this.#buildAbilities('ability', 'abilities')
             this.#buildAbilities('check', 'checks')
             this.#buildAbilities('save', 'saves')
             this.#buildCombat()
-            this.#buildEffects()
             this.#buildUtility()
         }
 


### PR DESCRIPTION
The `#buildEffects` method is `async`, but not `await`ed. This resulted in some (admittedly tricky to reproduce) flakiness when rendering the "Effects" group, which would sometimes go missing.