### PR TITLE
Retrieve effects using actor.allApplicableEffects

### DIFF
--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -541,7 +541,10 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
             const actionType = 'effect'
 
             // Get effects
-            const effects = this.actor.effects
+            const effects = new Map()
+            for (const effect of this.actor.allApplicableEffects()) {
+                effects.set(effect.id, effect)
+            }
 
             // Exit if no effects exist
             if (effects.size === 0) return

--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -413,7 +413,16 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
          */
         async #toggleEffect (event, actor, actionId) {
             const effects = 'find' in actor.effects.entries ? actor.effects.entries : actor.effects
-            const effect = effects.find(effect => effect.id === actionId)
+            let effect = effects.find(effect => effect.id === actionId)
+
+            // if the effect isn't directly on the actor, search all applicable effects for it
+            if (!effect) {
+                for (const e of actor.allApplicableEffects()) {
+                    if (e.id === actionId) {
+                        effect = e
+                    }
+                }
+            }
 
             if (!effect) return
 


### PR DESCRIPTION
Instead of checking actor.effects for effects, use the actor.allApplicableEffects() generator. 

This allows effects that don't originate from the actor themselves, such as effects granted by items, to show up and be toggleable in the HUD. A caveat is that this may allow players to accidentally delete effects like debuffs inflicted by GM-controlled creatures. 

Should fix #72 