### PR TITLE
Disallow deleting effects if not owned by actor

### DIFF
--- a/scripts/roll-handler.js
+++ b/scripts/roll-handler.js
@@ -415,8 +415,12 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
             const effects = 'find' in actor.effects.entries ? actor.effects.entries : actor.effects
             let effect = effects.find(effect => effect.id === actionId)
 
+            // only allow deletion if effect is directly on this actor
+            let internalEffect = true
+
             // if the effect isn't directly on the actor, search all applicable effects for it
             if (!effect) {
+                internalEffect = false
                 for (const e of actor.allApplicableEffects()) {
                     if (e.id === actionId) {
                         effect = e
@@ -428,7 +432,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
 
             const isRightClick = this.isRightClick(event)
 
-            if (isRightClick) {
+            if (isRightClick && internalEffect) {
                 await effect.delete()
             } else {
                 await effect.update({ disabled: !effect.disabled })


### PR DESCRIPTION
As noted by #79 and #80 , it is easy to accidentally right-click an effect and permanently remove it, which is not desirable for many externally-granted effects. 

This disallows doing so for external effects such as ones granted by items.  Right-clicking instead performs the same action as left-click, disabling the effect temporarily.

This should close #79, though I am not fully familiar with the old behavior so can't be certain if this replicates the functionality exactly. Prior to #75, external effects would not appear at all in the bar, and effects originating from the character could be just as easily removed by right-click. 

I agree with the suggestions of #79 and #80 that a confirmation message or option to change this behavior would be useful.