### PR TITLE
More item info fixes (very small)

### DIFF
--- a/scripts/action-handler.js
+++ b/scripts/action-handler.js
@@ -1358,13 +1358,13 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
          */
         #getUsesData (item, consumeName, consumeAmount) {
             const uses = item?.system?.uses
-            if (uses?.per && (uses.value > 0 || uses.max > 0)) {
+            if (uses?.per && (consumeName || uses?.prompt) && (uses.value > 0 || uses.max > 0)) {
                 const of = coreModule.api.Utils.i18n('DND5E.of')
-                const per = coreModule.api.Utils.i18n('DND5E.per')
-                const period = CONFIG.DND5E.limitedUsePeriods[`${uses.per}`].label
+                const per = uses.per === 'charges' ? '' : ` ${coreModule.api.Utils.i18n('DND5E.per')}`
+                const period = CONFIG.DND5E.limitedUsePeriods[uses.per].label
                 const amount = consumeAmount !== undefined ? consumeAmount : uses.amount
                 const text = `${amount > 1 ? `${amount} ${of} ` : ''}${uses.value ?? '0'}${uses.max > 0 ? `/${uses.max}` : ''}`
-                const title = `${uses.amount > 1 ? `/${uses.max}` : ''}${text} ${per} ${period}${consumeName ? ` (${of} ${consumeName})` : ''}`
+                const title = `${text}${per} ${period}${consumeName ? ` (${of} ${consumeName})` : ''}`
                 return { text, title }
             }
             return {}
@@ -1383,7 +1383,7 @@ Hooks.once('tokenActionHudCoreApiReady', async (coreModule) => {
             const consumeType = item?.system?.consume?.type
             const consumeAmount = item?.system?.consume?.amount
 
-            if (!consumeId || consumeId === item.id) return {}
+            if (!consumeId || !consumeType || consumeId === item.id) return {}
 
             // Return resources
             if (consumeType === 'attribute') {


### PR DESCRIPTION
Some things I noticed being off during my testing:

- Remove code left in accidentally, causing duplicate amount of charges used in tooltip
- Don't display consume amount if consume type is set to "none"
- Don't display uses value/max if promp is set to `false` (but do display these for items that consume uses of that item)
- Don't print the word "per" in front of "Charges" in tooltips